### PR TITLE
fix link

### DIFF
--- a/tagged/discovery.md
+++ b/tagged/discovery.md
@@ -138,8 +138,8 @@ _<sup>https://npmaddict.com</sup>_
 Your daily injection of npm packages.
 * **tags**: [node.js](../tagged/node.js.md), [discovery](../tagged/discovery.md)
 ---
-#### [npmcompare.com](https://npmcompare.com)
-_<sup>https://npmcompare.com</sup>_
+#### [npm-compare.com](https://npm-compare.com)
+_<sup>https://npm-compare.com</sup>_
 
 Compare and discover npm packages.
 * **tags**: [node.js](../tagged/node.js.md), [discovery](../tagged/discovery.md)


### PR DESCRIPTION
npmcompare.com is down now. I have replace it with new one: npm-compare.com